### PR TITLE
Move to a Tessellator based renderer

### DIFF
--- a/BlockNav/src/dllmain.cpp
+++ b/BlockNav/src/dllmain.cpp
@@ -1,53 +1,38 @@
 ﻿#include "dllmain.h"
 #include "ui/minimap/minimapRenderer.h"
 
-ClientInstance* client = nullptr;
-bool map_open = false;
+bool map_open = true;
 
 // Ran when the mod is loaded into the game by AmethystRuntime
 ModFunction void Initialize(HookManager* hookManager, Amethyst::EventManager* eventManager, InputManager* inputManager)
 {
-    // Logging from <Amethyst/Log.h>
-    Log::Info("Hello from C++!");
 
     // Add a listener to key inputs
     // https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-    inputManager->RegisterInput("use_map", 0x4D);
-    inputManager->AddButtonDownHandler("use_map", onUseMap);
+
+    // Inputs don't seem to work with amethysts hot reloading
+    // Removing for now... will add back later!
+    /*inputManager->RegisterInput("use_map", 0x4D);
+    inputManager->AddButtonDownHandler("use_map", toggleMapVisibility);*/
 
     // Add a listener to a built-in amethyst event
-    eventManager->onStartJoinGame.AddListener(&OnStartJoinGame);
     eventManager->onRequestLeaveGame.AddListener(onRequestLeaveGame);
-
     eventManager->onRenderUI.AddListener(&onRenderUi);
-}
-
-// Subscribed to amethysts on start join game event in Initialize
-void OnStartJoinGame(ClientInstance* clientInstance)
-{
-    client = clientInstance;
-
-    Log::Info("The player has joined the game!");
 }
 
 void onRequestLeaveGame()
 {
-    Log::Info("The player has top_left the game!");
-
     map_open = false;
 }
 
 void onRenderUi(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext)
 {
-    if (screenView->visualTree->mRootControlName->layerName == "hud_screen") {
-        if (map_open) {
-            MiniMapRenderer::Renderer(screenView, uiRenderContext, client);
-        }
+    if (screenView->visualTree->mRootControlName->layerName == "hud_screen" && map_open) {
+        MiniMapRenderer::Renderer(screenView, uiRenderContext);
     }
 }
 
-void onUseMap(FocusImpact focus, IClientInstance clientInstance)
+void toggleMapVisibility(FocusImpact focus, IClientInstance clientInstance)
 {
     map_open = !map_open;
-    Log::Info("Map");
 }

--- a/BlockNav/src/dllmain.h
+++ b/BlockNav/src/dllmain.h
@@ -16,4 +16,4 @@ void onRequestLeaveGame();
 
 void onRenderUi(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext);
 
-void onUseMap(FocusImpact focus, IClientInstance clientInstance);
+void toggleMapVisibility(FocusImpact focus, IClientInstance clientInstance);

--- a/BlockNav/src/ui/minimap/minimapRenderer.h
+++ b/BlockNav/src/ui/minimap/minimapRenderer.h
@@ -9,5 +9,5 @@
 
 class MiniMapRenderer {
 public:
-    static void Renderer(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext, ClientInstance* clientInstance);
+    static void Renderer(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext);
 };


### PR DESCRIPTION
**Motivation:**
Drawing the mini map using `MinecraftUIRenderContext` is incredibly slow, instead we can use the `Tessellator` class which can do this a lot more comfortably at high resolutions.

![image](https://github.com/Adrian8115/Bedrock-Insights/assets/69014593/2ae7f853-c0de-4ca4-a86a-2b9dd69a1373)

I've been able to achieve a 1 block per pixel scale at a fairly decent frame rate, only limited right now by the minimap not caching data, and not the drawing itself.

**Issues:**
- Right now the only material that I have found, seems to turn completely black when the hover outline is shown on screen for blocks.
- I also temporarily got rid of the toggle key-bind, because for whatever reason this causes amethysts hot-reloading system to crash, (this is an issue with amethyst itself), as hot-reloading is a must have for me!