### PR TITLE
Chunk based data caching & support translucency

### DIFF
--- a/AdvancedF3/src/dllmain.cpp
+++ b/AdvancedF3/src/dllmain.cpp
@@ -2,9 +2,7 @@
 #include "ui/f3/f3Renderer.h"
 #include "recorder/ps_recorder/psRecorder.h"
 
-ClientInstance* client = nullptr;
-bool map_open = false;
-bool f3_open = false;
+bool f3_open = true;
 
 // Ran when the mod is loaded into the game by AmethystRuntime
 ModFunction void Initialize(HookManager* hookManager, Amethyst::EventManager* eventManager, InputManager* inputManager) 
@@ -14,18 +12,15 @@ ModFunction void Initialize(HookManager* hookManager, Amethyst::EventManager* ev
 
     // Add a listener to key inputs
     // https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-    inputManager->RegisterInput("use_f3", 0x72);
-    inputManager->AddButtonDownHandler("use_f3", &onUseF3);
+    /*inputManager->RegisterInput("use_f3", 0x72);
+    inputManager->AddButtonDownHandler("use_f3", &onUseF3);*/
 
     //// Add a listener to a built-in amethyst event
-    eventManager->onStartJoinGame.AddListener(&OnStartJoinGame);
-    eventManager->onRequestLeaveGame.AddListener(onRequestLeaveGame);
-
     eventManager->onRenderUI.AddListener(&onRenderUi);
 
     psRecorder::registerEventHandlers(eventManager);
 
-    std::cout << "hwinfo is an open source, MIT licensed project that implements a platform independent "
+    /*std::cout << "hwinfo is an open source, MIT licensed project that implements a platform independent "
               << "hardware and system information gathering API for C++.\n\n"
               << "If you face any issues, find bugs or if your platform is not supported yet, do not hesitate to create "
               << "a ticket at https://github.com/lfreist/hwinfo/issues.\n\n"
@@ -165,37 +160,17 @@ ModFunction void Initialize(HookManager* hookManager, Amethyst::EventManager* ev
         std::cout << "No Disks installed or detected" << std::endl;
     }
 
-    Log::Info("THAT'S IT...");
+    Log::Info("THAT'S IT...");*/
 
-}
-
-// Subscribed to amethysts on start join game event in Initialize
-void OnStartJoinGame(ClientInstance* clientInstance)
-{
-    client = clientInstance;
-
-    Log::Info("The player has joined the game!");
-
-
-}
-
-void onRequestLeaveGame(){
-    Log::Info("The player has top_left the game!");
-
-    map_open = false;
-    f3_open = false;
 }
 
 void onRenderUi(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext)
 {
-    if (screenView->visualTree->mRootControlName->layerName == "hud_screen") {
-        if (f3_open) {
-            f3Renderer::Renderer(screenView, uiRenderContext, client);
-        }
+    if (screenView->visualTree->mRootControlName->layerName == "hud_screen" && f3_open) {
+        f3Renderer::Renderer(screenView, uiRenderContext);
     }
 }
 
 void onUseF3(FocusImpact focus, IClientInstance clientInstance){
     f3_open = !f3_open;
-    Log::Info("F3");
 }

--- a/AdvancedF3/src/ui/f3/f3Renderer.cpp
+++ b/AdvancedF3/src/ui/f3/f3Renderer.cpp
@@ -14,8 +14,12 @@ std::vector<std::string> control_data;
 
 int cycle = 0;
 
-void f3Renderer::Renderer(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext, ClientInstance* clientInstance) {
+void f3Renderer::Renderer(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext) {
     cycle++;
+    ClientInstance* clientInstance = uiRenderContext->mClient;
+
+    // Don't render unless in world
+    if (clientInstance->getLocalPlayer() == nullptr) return;
 
     if (cycle > 15) {
         cycle = 0;
@@ -41,8 +45,8 @@ void f3Renderer::Renderer(ScreenView* screenView, MinecraftUIRenderContext* uiRe
     Vec2 uiScreenSize = clientInstance->guiData->clientUIScreenSize;
 
     TextVectorRenderer::TextVectorTopLeftRenderer(screenView, uiRenderContext, info_data, uiScreenSize);
-    TextVectorRenderer::TextVectorTopRightRenderer(screenView, uiRenderContext, control_data, uiScreenSize);
+    //TextVectorRenderer::TextVectorTopRightRenderer(screenView, uiRenderContext, control_data, uiScreenSize);
 
-    TextVectorRenderer::TextVectorBottomLeftRenderer(screenView, uiRenderContext, extra_data, uiScreenSize);
-    TextVectorRenderer::TextVectorBottomRightRenderer(screenView, uiRenderContext, tool_tips, uiScreenSize);
+    //TextVectorRenderer::TextVectorBottomLeftRenderer(screenView, uiRenderContext, extra_data, uiScreenSize);
+    //TextVectorRenderer::TextVectorBottomRightRenderer(screenView, uiRenderContext, tool_tips, uiScreenSize);
 }

--- a/AdvancedF3/src/ui/f3/f3Renderer.h
+++ b/AdvancedF3/src/ui/f3/f3Renderer.h
@@ -9,5 +9,5 @@
 
 class f3Renderer{
 public:
-    static void Renderer(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext, ClientInstance* clientInstance);
+    static void Renderer(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext);
 };

--- a/BlockNav/src/dllmain.cpp
+++ b/BlockNav/src/dllmain.cpp
@@ -1,35 +1,32 @@
 ﻿#include "dllmain.h"
 #include "ui/minimap/minimapRenderer.h"
 
-bool map_open = false;
+Minimap minimap;
+bool map_open = true;
 
 // Ran when the mod is loaded into the game by AmethystRuntime
 ModFunction void Initialize(HookManager* hookManager, Amethyst::EventManager* eventManager, InputManager* inputManager)
 {
-
-    // Add a listener to key inputs
-    // https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-
-    // Inputs don't seem to work with amethysts hot reloading
-    // Removing for now... will add back later!
-    inputManager->RegisterInput("use_map", 0x4D);
-    inputManager->AddButtonDownHandler("use_map", toggleMapVisibility);
+    /*inputManager->RegisterInput("use_map", 0x4D);
+    inputManager->AddButtonDownHandler("use_map", toggleMapVisibility);*/
 
     // Add a listener to a built-in amethyst event
-    eventManager->onRequestLeaveGame.AddListener(onRequestLeaveGame);
+    eventManager->onRequestLeaveGame.AddListener(&onRequestLeaveGame);
     eventManager->onRenderUI.AddListener(&onRenderUi);
 }
 
 void onRequestLeaveGame()
 {
-    map_open = false;
+    minimap.OnLeaveGame();
 }
 
 void onRenderUi(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext)
 {
     if (screenView->visualTree->mRootControlName->layerName == "hud_screen" && map_open) {
-        MiniMapRenderer::Renderer(screenView, uiRenderContext);
+        minimap.Render(screenView, uiRenderContext);
     }
+
+    minimap.Update(uiRenderContext->mClient);
 }
 
 void toggleMapVisibility(FocusImpact focus, IClientInstance clientInstance)

--- a/BlockNav/src/ui/minimap/minimapRenderer.cpp
+++ b/BlockNav/src/ui/minimap/minimapRenderer.cpp
@@ -11,6 +11,116 @@
 #include <minecraft/src/common/world/level/block/Block.h>
 #include <minecraft/src/common/world/level/block/BlockLegacy.h>
 #include <minecraft/src-client/common/client/renderer/helpers/MeshHelpers.h>
+#include "../heightmap/HeightMapCalc.h"
+#include <algorithm>
+
+int frameCounter = 0;
+
+void Minimap::Update(ClientInstance* ci) {
+    if (ci->getLocalPlayer() == nullptr) return;
+
+    frameCounter++;
+
+    // Only add new chunks every so often
+    if (frameCounter >= 30) {
+        frameCounter = 0;
+        _AddChunksInRenderDistance(ci);
+    };
+
+    int chunksMappedThisFrame = 0;
+    
+    while (this->mChunksToMap.size() > 0 && chunksMappedThisFrame < mMaxChunksPerFrame) {
+        auto it = this->mChunksToMap.begin();
+        int64_t packed = *it;
+        this->mChunksToMap.erase(it);
+
+        ChunkPos chunkPos(packed);
+        this->_MapChunk(chunkPos, ci->getRegion());
+    }
+}
+
+void Minimap::_MapChunk(ChunkPos chunkPos, BlockSource* region) {
+    MinimapChunkData chunkData;
+
+    for (int localX = 0; localX < 16; localX++) {
+        for (int localZ = 0; localZ < 16; localZ++) {
+            int worldX = chunkPos.x * 16 + localX;
+            int worldZ = chunkPos.z * 16 + localZ;
+            int worldY = HeightMapCalc::getHeightMap(worldX, worldZ, region);
+
+            BlockPos pos = BlockPos(worldX, worldY, worldZ);
+            const Block block = region->getBlock(pos);
+            mce::Color color = block.mLegacyBlock->getMapColor(*region, pos, block);
+            float translucency = block.mLegacyBlock->mMaterial.mTranslucency;
+
+            // While we haven't found an opaque block
+            while (mUseTranslucency && translucency > 0.0f) {
+                worldY--;
+
+                if (worldY < region->getMinHeight()) break;
+
+                // Get the colour and translucency of the below block
+                BlockPos belowPos(worldX, worldY, worldZ);
+                const Block belowBlock = region->getBlock(belowPos);
+                mce::Color belowColor = belowBlock.mLegacyBlock->getMapColor(*region, belowPos, belowBlock);
+                float belowTranslucency = belowBlock.mLegacyBlock->mMaterial.mTranslucency;
+
+                if (belowBlock.mLegacyBlock->mMaterial.mType == MaterialType::Water) {
+                    belowTranslucency = 0.4f;
+                }
+
+                // If a block is fully transparent below other blocks than that would 
+                // result in a *0, so just skip this from happening
+                if (belowTranslucency == 1.0f) {
+                    continue;
+                }
+
+                // Calculate blending factors based on translucency
+                float blendFactor = 1.0f - translucency;
+                float belowBlendFactor = translucency * (1.0f - belowTranslucency);
+
+                // Blend colors
+                color.r = color.r * blendFactor + belowColor.r * belowBlendFactor;
+                color.g = color.g * blendFactor + belowColor.g * belowBlendFactor;
+                color.b = color.b * blendFactor + belowColor.b * belowBlendFactor;
+
+                // Update translucency for the next block
+                translucency = belowTranslucency;
+            }
+
+            color.a = 1.0f;
+
+            chunkData.colors[localX][localZ] = color;
+        }
+    }
+
+    this->mChunkData[chunkPos.packed] = chunkData;
+}
+
+void Minimap::_AddChunksInRenderDistance(ClientInstance* ci) {
+    LocalPlayer* player = ci->getLocalPlayer();
+    if (player == nullptr) return;
+
+    Vec3* pos = player->getPosition();
+    int chunkX = (int)pos->x / 16;
+    int chunkZ = (int)pos->z / 16;
+
+    for (int x = chunkX - mRenderDistance - mRenderSafeZone; x < chunkX + mRenderDistance + mRenderSafeZone; x++) {
+        for (int z = chunkZ - mRenderDistance - mRenderSafeZone; z < chunkZ + mRenderDistance + mRenderSafeZone; z++) {
+            ChunkPos chunkPos(x, z);
+            auto it = this->mChunkData.find(chunkPos.packed);
+
+            if (it == this->mChunkData.end()) {
+                this->mChunksToMap.insert(chunkPos.packed);
+            }
+        }
+    }
+
+    if (this->mChunksToMap.size() < this->mMaxChunksPerFrame) {
+        ChunkPos originChunk(chunkX, chunkZ);
+        this->mChunksToMap.insert(originChunk.packed);
+    }
+}
 
 // The vertexes for two triangles on a unit square
 // In clock-wise order
@@ -19,7 +129,7 @@ Vec3 vertexes[6] = {
     Vec3(0.0f, 1.0f, 0.0f), Vec3(1.0f, 1.0f, 0.0f), Vec3(1.0f, 0.0f, 0.0f)
 };
 
-void MiniMapRenderer::Renderer(ScreenView* screenView, MinecraftUIRenderContext* ctx)
+void Minimap::Render(ScreenView* screenView, MinecraftUIRenderContext* ctx)
 {
     ClientInstance* ci = ctx->mClient;
     LocalPlayer* player = ci->getLocalPlayer();
@@ -27,13 +137,14 @@ void MiniMapRenderer::Renderer(ScreenView* screenView, MinecraftUIRenderContext*
     // Still loading into the world!
     if (player == nullptr) return;
 
+    Vec2 uiScreenSize = ci->guiData->clientUIScreenSize;
+
     // Minimap options
-    Vec2 minimapScreenSize = Vec2(128.0f, 128.0f);
-    int widthInBlocks = 128*2;
+    Vec2 minimapScreenSize = Vec2(120.0f, 120.0f);
+    int widthInBlocks = mRenderDistance * 2 * 16;
     float pixelsPerBlock = (float)minimapScreenSize.x / widthInBlocks;
 
     // Placement of the minimap on the screen
-    Vec2 uiScreenSize = ci->guiData->clientUIScreenSize;
     float left = uiScreenSize.x - minimapScreenSize.x - UiConfig::offset;
     float bottom = UiConfig::offset + minimapScreenSize.y;
 
@@ -49,13 +160,26 @@ void MiniMapRenderer::Renderer(ScreenView* screenView, MinecraftUIRenderContext*
     tes->mNoColor = false;
 
     for (int x = 0; x < widthInBlocks; x++) {
-        for (int y = 0; y < widthInBlocks; y++) {
+        for (int z = 0; z < widthInBlocks; z++) {
             float pixelLeft = left + x * pixelsPerBlock;
-            float pixelBottom = bottom - y * pixelsPerBlock;
+            float pixelBottom = bottom - z * pixelsPerBlock;
 
-            // This data urgently needs to be cached, this is not good
-            mce::Color color = NormalMode::getColorFromPosCached(mapMinX + x, playerY, mapMinZ + y, region);
-            tes->color(color.r, color.g, color.b, 1);
+            int chunkX = (mapMinX + x) / 16;
+            int chunkZ = (mapMinZ + z) / 16;
+
+            mce::Color color(0.0f, 0.0f, 0.0f, 1.0f);
+
+            ChunkPos chunkPos(chunkX, chunkZ);
+            auto it = mChunkData.find(chunkPos.packed);
+
+            if (mChunkData.find(chunkPos.packed) != mChunkData.end()) {
+                int localX = abs((mapMinX + x) % 16);
+                int localZ = abs((mapMinZ + z) % 16);
+
+                color = it->second.colors[localX][localZ];
+            }
+
+            tes->color(color.r, color.g, color.b, color.a);
 
             for (Vec3 vertex : vertexes) {
                 float vertexX = vertex.x * pixelsPerBlock + pixelLeft;
@@ -69,4 +193,9 @@ void MiniMapRenderer::Renderer(ScreenView* screenView, MinecraftUIRenderContext*
     // We need to find another material because this one goes black when it is showing a hover outline
     mce::MaterialPtr* mat = *reinterpret_cast<mce::MaterialPtr**>(SlideAddress(0x572A440));
     MeshHelpers::renderMeshImmediately(ctx->mScreenContext, tes, mat);
+}
+
+void Minimap::OnLeaveGame() {
+    mChunkData.clear();
+    mChunksToMap.clear();
 }

--- a/BlockNav/src/ui/minimap/minimapRenderer.h
+++ b/BlockNav/src/ui/minimap/minimapRenderer.h
@@ -6,8 +6,47 @@
 #include <amethyst/HookManager.h>
 #include <amethyst/InputManager.h>
 #include <amethyst/events/EventManager.h>
+#include <minecraft/src/common/world/level/ChunkPos.h>
+#include <array>
+#include <queue>
 
-class MiniMapRenderer {
+class Minimap {
+private:
+    struct MinimapChunkData {
+        std::array<std::array<mce::Color, 16>, 16> colors;
+    };
+
+    std::unordered_map<int64_t, MinimapChunkData> mChunkData;
+    std::unordered_set<int64_t> mChunksToMap;
+
 public:
-    static void Renderer(ScreenView* screenView, MinecraftUIRenderContext* uiRenderContext);
+    /*
+    The number of chunks to render on the map
+    */
+    int mRenderDistance = 6;
+
+    /*
+    The number of chunks extra that should be loaded around the current render distance
+    Prevents black zones around the edges of the map, but takes extra performance
+    */
+    int mRenderSafeZone = 1;
+
+    /*
+    The max number of new chunks that should be read per frame
+    */
+    int mMaxChunksPerFrame = 1;
+
+    /*
+    Should the transparency of blocks be considered?
+    */
+    bool mUseTranslucency = true;
+
+public:
+    void Update(ClientInstance* client);
+    void Render(ScreenView* screenView, MinecraftUIRenderContext* ctx);
+    void OnLeaveGame();
+
+private:
+    void _AddChunksInRenderDistance(ClientInstance* client);
+    void _MapChunk(ChunkPos chunkPos, BlockSource* region);
 };


### PR DESCRIPTION
![image](https://github.com/Adrian8115/Bedrock-Insights/assets/69014593/6cb38615-dd64-40e4-830e-8a1b0dd5b8d5)

Switches to a chunk based caching system, and also adds translucency

**Issues:**
- the mini map needs to be flipped horizontally
- the mini map renders black when loading into the world (need to wait)
- the mini map breaks when in negative coordinates (the chunks flip, u just gotta change the math)
- we need to unload chunks in the mini map when far away cus its pointless to keep them in memory
- when a waterlogged block is placed in 1 block deep water, the map won't show the water colour 